### PR TITLE
returning empty for tenants query when promise val is undefined

### DIFF
--- a/src/ui/api/controllers/tenant_controller.ts
+++ b/src/ui/api/controllers/tenant_controller.ts
@@ -24,7 +24,7 @@ export class TenantController extends BaseController {
         if (!tenantName) return await this._tenantRepository.findAll();
         return await this._tenantRepository.findOneByQuery({
             name: tenantName
-        });
+        }) || [];
     }
     @httpPost("/", authMiddleware({ role: UserRole.ADMIN }))
     public async post(@requestBody() input: CreateTenantInput) {


### PR DESCRIPTION
went for a pretty simple approach because I wasn't sure if you would always want the `findOneByQuery` returning an `[]` instead of `undefined`